### PR TITLE
Add HTTP DELETE support

### DIFF
--- a/proxy.rb
+++ b/proxy.rb
@@ -38,6 +38,8 @@ app = Proc.new do |env|
     response = client.get "#{env['REQUEST_PATH']}?#{env['QUERY_STRING']}", {}, headers
   elsif env['REQUEST_METHOD'] == 'HEAD'
     response = client.head "#{env['REQUEST_PATH']}?#{env['QUERY_STRING']}", {}, headers
+  elsif env['REQUEST_METHOD'] == 'DELETE'
+    response = client.delete "#{env['REQUEST_PATH']}?#{env['QUERY_STRING']}", {}, headers
   elsif env['REQUEST_METHOD'] == 'POST'
     response = client.post "#{env['REQUEST_PATH']}?#{env['QUERY_STRING']}", "#{postdata}", headers
   elsif env['REQUEST_METHOD'] == 'OPTIONS'


### PR DESCRIPTION
Supporting HTTP Delete which is for example needed to delete indices from AWS ElasticSearch Service